### PR TITLE
Use casbin as the authorization library.

### DIFF
--- a/filters/Filter.go
+++ b/filters/Filter.go
@@ -4,7 +4,7 @@ import (
     "github.com/astaxie/beego/context"
     "pybbs-go/models"
     "github.com/astaxie/beego"
-    "regexp"
+    "strconv"
 )
 
 func IsLogin(ctx *context.Context) (bool, models.User) {
@@ -21,16 +21,9 @@ var HasPermission = func(ctx *context.Context) {
     if !ok {
         ctx.Redirect(302, "/login")
     } else {
-        permissions := models.FindPermissionByUser(user.Id)
         url := ctx.Request.RequestURI
         beego.Debug("url: ", url)
-        var flag = false
-        for _, v := range permissions {
-            if a, _ := regexp.MatchString(v.Url, url); a {
-                flag = true
-                break
-            }
-        }
+        flag := models.Enforcer.Enforce(strconv.Itoa(user.Id), url)
         if !flag {
             ctx.WriteString("你没有权限访问这个页面")
         }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func init() {
 		new(models.Role),
 		new(models.Permission))
 	orm.RunSyncdb("default", false, true)
+
+	models.Init()
 }
 
 func main() {

--- a/models/Permission.go
+++ b/models/Permission.go
@@ -1,6 +1,9 @@
 package models
 
-import "github.com/astaxie/beego/orm"
+import (
+	"github.com/astaxie/beego/orm"
+	"strconv"
+)
 
 type Permission struct {
 	Id               int `orm:"pk;auto"`
@@ -48,11 +51,15 @@ func UpdatePermission(permission *Permission) int64 {
 }
 
 func DeletePermission(permission *Permission) {
+	Enforcer.DeletePermission(strconv.Itoa(permission.Id))
+
 	o := orm.NewOrm()
 	o.Delete(permission)
 }
 
 func DeleteRolePermissionByPermissionId(permission_id int) {
+	Enforcer.DeletePermission(strconv.Itoa(permission_id))
+
 	o := orm.NewOrm()
 	o.Raw("delete from role_permissions where permission_id = ?", permission_id).Exec()
 }

--- a/models/Role.go
+++ b/models/Role.go
@@ -1,6 +1,9 @@
 package models
 
-import "github.com/astaxie/beego/orm"
+import (
+	"github.com/astaxie/beego/orm"
+	"strconv"
+)
 
 type Role struct {
 	Id          int `orm:"pk;auto"`
@@ -36,16 +39,22 @@ func UpdateRole(role *Role) {
 }
 
 func DeleteRole(role *Role) {
+	Enforcer.DeleteRole(strconv.Itoa(role.Id))
+
 	o := orm.NewOrm()
 	o.Delete(role)
 }
 
 func DeleteRolePermissionByRoleId(role_id int) {
+	Enforcer.DeletePermissionsForUser(strconv.Itoa(role_id))
+
 	o := orm.NewOrm()
 	o.Raw("delete from role_permissions where role_id = ?", role_id).Exec()
 }
 
 func SaveRolePermission(role_id int, permission_id int) {
+	Enforcer.AddPermissionForUser(strconv.Itoa(role_id), strconv.Itoa(permission_id))
+
 	o := orm.NewOrm()
 	o.Raw("insert into role_permissions (role_id, permission_id) values (?, ?)", role_id, permission_id).Exec()
 }

--- a/rbac_model.conf
+++ b/rbac_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, act
+
+[policy_definition]
+p = sub, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = g(r.sub, p.sub) && regexMatch(r.act, p.act.url)


### PR DESCRIPTION
The enforcement logic are replaced with [casbin](https://github.com/hsluoyz/casbin). The roles and permissions are loaded into casbin in the ``Init()`` function dynamically. All original DB tables are remained.